### PR TITLE
fix: semaphore reuse

### DIFF
--- a/10.a-render-to-texture/10.a-render-to-texture.cpp
+++ b/10.a-render-to-texture/10.a-render-to-texture.cpp
@@ -61,7 +61,7 @@ public:
             nullptr);
         graphicsQueue->submit(commandBuffers[bufferIndex], stageMask,
             rtSemaphore, // Wait for render-to-texture
-            renderFinished, // Semaphore to be signaled when command buffer completed execution
+            *renderFinished, // Semaphore to be signaled when command buffer completed execution
             *waitFence); // Fence to be signaled when command buffer completed execution
     }
 

--- a/10.b-render-to-msaa-texture/10.b-render-to-msaa-texture.cpp
+++ b/10.b-render-to-msaa-texture/10.b-render-to-msaa-texture.cpp
@@ -68,7 +68,7 @@ public:
             nullptr);
         graphicsQueue->submit(commandBuffers[bufferIndex], stageMask,
             rtSemaphore, // Wait for render-to-texture
-            renderFinished, // Semaphore to be signaled when command buffer completed execution
+            *renderFinished, // Semaphore to be signaled when command buffer completed execution
             *waitFence); // Fence to be signaled when command buffer completed execution
     }
 

--- a/13-specialization/13-specialization.cpp
+++ b/13-specialization/13-specialization.cpp
@@ -85,7 +85,7 @@ public:
             commandBuffers[bufferIndex][pipelineIndex],
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
             presentFinished,
-            renderFinished,
+            *renderFinished,
             *waitFence);
     }
 

--- a/framework/vulkanApp.cpp
+++ b/framework/vulkanApp.cpp
@@ -331,10 +331,11 @@ void VulkanApp::createCommandBuffers()
 void VulkanApp::createSyncPrimitives()
 {
     presentFinished = std::make_shared<magma::Semaphore>(device);
-    for (int i = 0; i < (int)swapchain->getImageCount(); ++i)
-        renderFinishedSemaphores.push_back(std::make_shared<magma::Semaphore>(device));
     for (int i = 0; i < (int)commandBuffers.size(); ++i)
+    {
+        renderFinishedSemaphores.push_back(std::make_shared<magma::Semaphore>(device));
         waitFences.push_back(std::make_unique<magma::Fence>(device, nullptr, VK_FENCE_CREATE_SIGNALED_BIT));
+    }
 }
 
 void VulkanApp::createDescriptorPool()

--- a/framework/vulkanApp.h
+++ b/framework/vulkanApp.h
@@ -71,7 +71,9 @@ protected:
     std::shared_ptr<magma::CommandBuffer> cmdBufferCopy;
 
     std::shared_ptr<magma::Semaphore> presentFinished;
-    std::shared_ptr<magma::Semaphore> renderFinished;
+    std::vector<std::shared_ptr<magma::Semaphore>> renderFinishedSemaphores;
+    const std::shared_ptr<magma::Semaphore> nullSemaphore;
+    const std::shared_ptr<magma::Semaphore> *renderFinished;
     std::vector<std::unique_ptr<magma::Fence>> waitFences;
     const std::unique_ptr<magma::Fence> nullFence;
     const std::unique_ptr<magma::Fence> *waitFence;


### PR DESCRIPTION
Fixed vkQueuePresentKHR semaphore reuse causing error of validation layer and segfault during termination.
Probably warrants some further testing.

Could change the bound of the for loop to
`for (int i = 0; i < (int)commandBuffers.size(); ++i)`
Not sure which is cleaner.